### PR TITLE
MainWindow: Fix critical message on startup

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -89,7 +89,7 @@ public class Rollit.MainWindow : Gtk.Window {
 
         roll_button = new Gtk.Button.with_label (_("Roll")) {
             width_request = 96,
-            tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>R", "R"}, roll_button.label)
+            tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl>R", "R"}, _("Roll"))
         };
         roll_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
 


### PR DESCRIPTION
Fixes #2

Values specified to properties in the `{…}` is set before initializing the object itself as you can see in the generated C code, so you can't refer to the object itself there.

```c
static GObject *
rollit_main_window_constructor (GType type,
                                guint n_construct_properties,
                                GObjectConstructParam * construct_properties)
{
:

#line 90 "../src/MainWindow.vala"
	_tmp24_ = gtk_button_get_label (_tmp23_);
#line 90 "../src/MainWindow.vala"
	_tmp25_ = _tmp24_;
#line 90 "../src/MainWindow.vala"
	_tmp26_ = granite_markup_accel_tooltip (_tmp22_, (gint) 2, _tmp25_);
#line 90 "../src/MainWindow.vala"
	_tmp27_ = (GtkButton*) gtk_button_new_with_label (_ ("Roll"));
```
